### PR TITLE
Refactor marching to use implicit normal

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -41,7 +41,7 @@ const int image_width = 400;
 const int image_height = static_cast<int>(image_width / aspect_ratio);
 
 // Anti aliasing
-const int rays_per_pixel = 16;
+const int rays_per_pixel = 10;
 
 // Parallelization
 const bool RENDER_PARALLEL = false;

--- a/src/diffuse.cpp
+++ b/src/diffuse.cpp
@@ -1,16 +1,16 @@
 #include "diffuse.h"
 
-vec3 flat::color(const ray& r, double t, vec3 N, std::vector<light> lights) const {
+vec3 flat::color(const ray& r, vec3 p, vec3 N, std::vector<light> lights) const {
     // Flat color
     return albedo;
 }
 
-vec3 normals::color(const ray& r, double t, vec3 N, std::vector<light> lights) const {
+vec3 normals::color(const ray& r, vec3 p, vec3 N, std::vector<light> lights) const {
     // Color as a function of surface normal
     return 0.5*vec3(N.x()+1, N.y()+1, N.z()+1);
 }
 
-vec3 diffuse::color(const ray& r, double t, vec3 N, std::vector<light> lights) const {
+vec3 diffuse::color(const ray& r, vec3 p, vec3 N, std::vector<light> lights) const {
     // Simple diffuse approximation
     vec3 C;
 

--- a/src/diffuse.h
+++ b/src/diffuse.h
@@ -11,7 +11,7 @@ class flat : public material {
 public:
     flat(): albedo(vec3::random()) {};
     explicit flat(const vec3& alb): albedo(alb) {};
-    vec3 color(const ray& r, double t, vec3 N, std::vector<light> lights) const override;
+    vec3 color(const ray& r, vec3 p, vec3 N, std::vector<light> lights) const override;
 
 public:
     vec3 albedo;
@@ -21,7 +21,7 @@ public:
 class normals : public material {
 public:
     normals() = default;
-    vec3 color(const ray& r, double t, vec3 N, std::vector<light> lights) const override;
+    vec3 color(const ray& r, vec3 p, vec3 N, std::vector<light> lights) const override;
 };
 
 // Diffuse material
@@ -34,7 +34,7 @@ public:
         Ka(mat_ka), Kd(mat_kd), Ks(mat_ks),
         la(l_amb), spec(spower) {};
 
-    vec3 color(const ray& r, double t, vec3 N, std::vector<light> lights) const override;
+    vec3 color(const ray& r, vec3 p, vec3 N, std::vector<light> lights) const override;
 
 public:
     vec3 Ka;

--- a/src/hit_record.h
+++ b/src/hit_record.h
@@ -6,7 +6,7 @@
 
 // Stores intersection information
 struct hit_record {
-    double t;
+    vec3 p;
     vec3 N;
     shared_ptr<material> mat_ptr;
 };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -41,7 +41,7 @@ scene diffuse_scene() {
     auto s2 = make_shared<sphere>(
             vec3(0, 0, -2), 0.5,
             make_shared<normals>());
-    auto s3 = make_shared<sphere>(
+    auto s3 = make_shared<perturbed_sphere>(
             vec3(1.1, 0, -2), 0.5, d1);
 
     world.add_surface(s1);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -42,7 +42,7 @@ scene diffuse_scene() {
             vec3(0, 0, -2), 0.5,
             make_shared<normals>());
     auto s3 = make_shared<perturbed_sphere>(
-            vec3(1.1, 0, -2), 0.5, d1);
+            vec3(1.1, 0, -2), 0.5, 9.0, 0.11, d1);
 
     world.add_surface(s1);
     world.add_surface(s2);

--- a/src/material.h
+++ b/src/material.h
@@ -15,7 +15,7 @@ public:
      * N - surface normal at intersection
      * lights - vector of directional lights
      */
-    virtual vec3 color(const ray &r, double t, vec3 N, std::vector<light> lights) const = 0;
+    virtual vec3 color(const ray &r, vec3 p, vec3 N, std::vector<light> lights) const = 0;
 };
 
 #endif //MATERIAL_H

--- a/src/scene.cpp
+++ b/src/scene.cpp
@@ -23,10 +23,11 @@ bool scene::march(const ray& r, hit_record& rec) {
     // March along a ray by the distance to the nearest surface
     double t = 0;
     while(t < 10) {
-        double dist = distance_estimator(r.at(t));
+        vec3 p = r.at(t);
+        double dist = distance_estimator(p);
         if (near_zero(dist) || dist < 0) {
-            rec.t = t;
-            rec.N = nearest->normal(r.at(t));
+            rec.p = p;
+            rec.N = normal(p);
             rec.mat_ptr = nearest->mat_ptr;
             return true;
         }
@@ -36,12 +37,25 @@ bool scene::march(const ray& r, hit_record& rec) {
     return false;
 }
 
+vec3 scene::normal(const vec3 &p) {
+    const vec3 stepx(0.001, 0.0, 0.0);
+    const vec3 stepy(0.0, 0.001, 0.0);
+    const vec3 stepz(0.0, 0.0, 0.001);
+
+    double gradx = distance_estimator(p + stepx) - distance_estimator(p - stepx);
+    double grady = distance_estimator(p + stepy) - distance_estimator(p - stepy);
+    double gradz = distance_estimator(p + stepz) - distance_estimator(p - stepz);
+
+    vec3 normal(gradx, grady, gradz);
+    return normalize(normal);
+}
+
 vec3 scene::ray_color(const ray& r) {
     // Return the color of a surface at the ray intersection if it hits,
     // otherwise return the color of the background
     hit_record rec;
     if (march(r, rec))
-        return rec.mat_ptr->color(r, rec.t, rec.N, lights);
+        return rec.mat_ptr->color(r, rec.p, rec.N, lights);
     vec3 unit_direction = normalize(r.direction());
     auto t = 0.5*(unit_direction.y() + 1.0);
     return (1.0-t)*vec3(1.0, 1.0, 1.0) + t*vec3(0.5, 0.7, 1.0);

--- a/src/scene.h
+++ b/src/scene.h
@@ -17,6 +17,7 @@ public:
 
     double distance_estimator(vec3 p);
     bool march(const ray& r, hit_record& rec);
+    vec3 normal(const vec3& p);
     vec3 ray_color(const ray& r);
 
 public:

--- a/src/sphere.h
+++ b/src/sphere.h
@@ -1,6 +1,8 @@
 #ifndef SPHERE_H
 #define SPHERE_H
 
+#include <utility>
+
 #include "common.h"
 #include "surface.h"
 
@@ -20,14 +22,25 @@ public:
 
 class perturbed_sphere : public sphere {
 public:
-    perturbed_sphere(const vec3& cen, double r, shared_ptr<material> m) : sphere(cen, r, m) {};
+    perturbed_sphere(const vec3& cen, double r, double phase,
+                     double intensity, shared_ptr<material> m) :
+                     sphere(cen, r, std::move(m)) {
+        ph = phase;
+        ints = intensity;
+    };
 
     double distance(const vec3& p) const override {
-        double displacement = sin(7.0 * p.x())
-                              * sin(7.0 * p.y())
-                              * sin(7.0 * p.z()) * 0.1;
+        double displacement = sin(ph * p.x())
+                              * sin(ph * p.y())
+                              * sin(ph * p.z()) * ints;
         return (p - center).length() - radius + displacement;
     };
+
+public:
+    double ph;
+    double ints;
 };
+
+
 
 #endif

--- a/src/sphere.h
+++ b/src/sphere.h
@@ -13,13 +13,21 @@ public:
         return (p - center).length() - radius;
     };
 
-    vec3 normal(const vec3& p) const override {
-        return normalize(p - center);
-    };
-
 public:
     vec3 center;
     double radius{};
+};
+
+class perturbed_sphere : public sphere {
+public:
+    perturbed_sphere(const vec3& cen, double r, shared_ptr<material> m) : sphere(cen, r, m) {};
+
+    double distance(const vec3& p) const override {
+        double displacement = sin(7.0 * p.x())
+                              * sin(7.0 * p.y())
+                              * sin(7.0 * p.z()) * 0.1;
+        return (p - center).length() - radius + displacement;
+    };
 };
 
 #endif

--- a/src/sphere.h
+++ b/src/sphere.h
@@ -41,6 +41,4 @@ public:
     double ints;
 };
 
-
-
 #endif

--- a/src/surface.h
+++ b/src/surface.h
@@ -14,7 +14,6 @@ public:
      */
     explicit surface(shared_ptr<material> m): mat_ptr(std::move(m)) {}
     virtual double distance(const vec3& p) const = 0;
-    virtual vec3 normal(const vec3& p) const = 0;
 
 public:
     shared_ptr<material> mat_ptr;


### PR DESCRIPTION
Previously we used explicit surface normals for spheres. This change refactors scene to calculate an implicit normal, and removes the responsibility of normals from surfaces. It also adds a slight refactor to hit record to store the point rather than frequently calling ray.at(t) and adds a perturbed sphere surface type.